### PR TITLE
[FEAT] bug fixes and improvements

### DIFF
--- a/daft_launcher/cli.py
+++ b/daft_launcher/cli.py
@@ -80,8 +80,8 @@ def config_option(func):
     )(func)
 
 
-def cmd_args_option(func):
-    return click.option("--cmd", required=True, type=click.STRING)(func)
+def cmd_args_argument(func):
+    return click.argument("cmd_args", nargs=-1, type=click.UNPROCESSED, required=True)(func)
 
 
 def init_config_command(func):
@@ -146,17 +146,17 @@ def dashboard(
 @config_option
 @working_dir_option
 @identity_file_option
-@cmd_args_option
+@cmd_args_argument
 def submit(
     config: Optional[Path],
     identity_file: Optional[Path],
     working_dir: Path,
-    cmd: str,
+    cmd_args: tuple[str],
 ):
     config = get_config_path(config)
     assert_identity_file_path(identity_file)
     assert_working_dir(working_dir)
-    commands.submit(config, identity_file, working_dir, cmd)
+    commands.submit(config, identity_file, working_dir, cmd_args)
 
 
 @down_command

--- a/daft_launcher/commands.py
+++ b/daft_launcher/commands.py
@@ -89,8 +89,9 @@ def submit(
     config: Path,
     identity_file: Optional[Path],
     working_dir: Path,
-    cmd: str,
+    cmd_args: tuple[str],
 ):
+    cmd = " ".join([arg for arg in cmd_args])
     process = subprocess.Popen(
         helpers.ssh_command(
             helpers.get_ip(config), Path(identity_file) if identity_file else None

--- a/daft_launcher/helpers.py
+++ b/daft_launcher/helpers.py
@@ -22,8 +22,15 @@ def get_ip(config: Path):
             "Reservations[*].Instances[*].{State:State.Name,Tags:Tags,Ip:PublicIpAddress}",
         ],
     )
-    ip, state = find_ip(instance_groups, name)
-    if state != "running":
+    state_to_ips_mapping = find_ip(instance_groups, name)
+    if 'running' not in state_to_ips_mapping:
+        raise click.UsageError(
+            f"The cluster {name} is not running; cannot connect to it."
+        )
+    assert len(state_to_ips_mapping['running']) <= 1
+    if state_to_ips_mapping['running']:
+        ip = state_to_ips_mapping['running'][0]
+    else:
         raise click.UsageError(
             f"The cluster {name} is not running; cannot connect to it."
         )
@@ -51,8 +58,15 @@ def run_aws_command(args: list[str]) -> Any:
         raise click.UsageError(f"Failed to parse AWS command output: {result.stdout}")
 
 
-def find_ip(instance_groups: List[List[Any]], name: str) -> tuple[Optional[str], str]:
+def find_ip(instance_groups: List[List[Any]], name: str) -> dict[str, list[Optional[str]]]:
     ip = None
+    state_to_ips_mapping: dict[str, list[Optional[str]]] = {}
+    def insert(state: str, ip: Optional[str]):
+        if state in state_to_ips_mapping:
+            state_to_ips_mapping[state].append(ip)
+        else:
+            state_to_ips_mapping[state] = [ip]
+
     for instance_group in instance_groups:
         for instance in instance_group:
             is_head = False
@@ -64,8 +78,12 @@ def find_ip(instance_groups: List[List[Any]], name: str) -> tuple[Optional[str],
                 elif tag["Key"] == "ray-node-type":
                     is_head = tag["Value"] == "head"
             if is_head and cluster_name == name:
-                return instance["Ip"], state
-    raise click.UsageError(f"The IP of the cluster with the name '{name}' not found.")
+                insert(state, instance["Ip"])
+
+    if not state_to_ips_mapping:
+        raise click.UsageError(f"The IP of the cluster with the name '{name}' not found.")
+
+    return state_to_ips_mapping
 
 
 def ssh_command(


### PR DESCRIPTION
# Overview
- change `config` argument to `--config` option
- change `--cmd "..."` option to `-- ...` after-marker list of args
- fix bug in submit where it eagerly grab the first terminated instance with the same name as another running instance (thus causing an error being reported that "cluster XYZ is not running right now!")