### PR TITLE
[FEAT] Add ability to specify permissions to worker nodes as well

### DIFF
--- a/daft_launcher/cli.py
+++ b/daft_launcher/cli.py
@@ -37,8 +37,13 @@ def assert_working_dir(working_dir: Path):
 
 def get_new_configuration_file_path(name: Optional[Path]) -> Path:
     name = name or DEFAULT_CONFIG_PATH
-    if name.exists():
+    if name.is_file():
         raise click.UsageError(f"A configuration file at path {name} already exists.")
+    elif name.is_dir():
+        raise click.UsageError(f"That is the path to a directory; please pass in a file name.")
+    elif name.exists():
+        raise click.UsageError(f"That path already exists; please use a new one.")
+
     return name
 
 

--- a/daft_launcher/commands.py
+++ b/daft_launcher/commands.py
@@ -32,6 +32,7 @@ def init_config(name: Path):
     with open(AWS_TEMPLATE_PATH) as template_f:
         with open(name, "w") as config_f:
             config_f.write(template_f.read())
+            print(f"Successfully created a new configuration file: {name}")
 
 
 def up(config: Path):

--- a/daft_launcher/configs.py
+++ b/daft_launcher/configs.py
@@ -133,7 +133,9 @@ def merge(
         for b_i in b:
             y = ray_config
             for b_ii in b_i[:-1]:
-                y = y.get(b_ii, {})
+                if b_ii not in y:
+                    y[b_ii] = {}
+                y = y[b_ii]
             y[b_i[-1]] = value
 
     setup_commands: list[str] = ray_config["setup_commands"]

--- a/daft_launcher/configs.py
+++ b/daft_launcher/configs.py
@@ -133,7 +133,7 @@ def merge(
         for b_i in b:
             y = ray_config
             for b_ii in b_i[:-1]:
-                y = y[b_ii]
+                y = y.get(b_ii, {})
             y[b_i[-1]] = value
 
     setup_commands: list[str] = ray_config["setup_commands"]

--- a/daft_launcher/configs.py
+++ b/daft_launcher/configs.py
@@ -74,6 +74,26 @@ def get_ray_config(
                 ],
                 False,
             ),
+            (
+                "iam_instance_profile_arn",
+                [
+                    [
+                        "available_node_types",
+                        "ray.head.default",
+                        "node_config",
+                        "IamInstanceProfile",
+                        "Arn",
+                    ],
+                    [
+                        "available_node_types",
+                        "ray.worker.default",
+                        "node_config",
+                        "IamInstanceProfile",
+                        "Arn",
+                    ],
+                ],
+                False,
+            ),
         ]
     else:
         raise click.UsageError(f"Cloud provider {provider} not found")

--- a/daft_launcher/ray_default_configs/aws.yaml
+++ b/daft_launcher/ray_default_configs/aws.yaml
@@ -15,8 +15,6 @@ available_node_types:
     node_config:
       InstanceType: m7g.medium
       ImageId: ami-01c3c55948a949a52
-      IamInstanceProfile:
-        Arn:
 
   ray.worker.default:
     min_workers: 2
@@ -25,8 +23,6 @@ available_node_types:
     node_config:
       InstanceType: m7g.medium
       ImageId: ami-01c3c55948a949a52
-      IamInstanceProfile:
-        Arn:
 
 setup_commands:
   - curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/daft_launcher/ray_default_configs/aws.yaml
+++ b/daft_launcher/ray_default_configs/aws.yaml
@@ -15,6 +15,8 @@ available_node_types:
     node_config:
       InstanceType: m7g.medium
       ImageId: ami-01c3c55948a949a52
+      IamInstanceProfile:
+        Arn:
 
   ray.worker.default:
     min_workers: 2
@@ -23,6 +25,8 @@ available_node_types:
     node_config:
       InstanceType: m7g.medium
       ImageId: ami-01c3c55948a949a52
+      IamInstanceProfile:
+        Arn:
 
 setup_commands:
   - curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/daft_launcher/templates/aws.toml
+++ b/daft_launcher/templates/aws.toml
@@ -12,6 +12,9 @@
 name = "daft-launcher-example"
 provider = "aws"
 
+# (required - please provide an IAM Instance Profile ARN)
+iam_instance_profile_arn = "$IAM_INSTANCE_PROFILE_ARN"
+
 # (defaults to "us-west-2")
 # region = "$REGION"
 

--- a/daft_launcher/templates/aws.toml
+++ b/daft_launcher/templates/aws.toml
@@ -12,7 +12,7 @@
 name = "daft-launcher-example"
 provider = "aws"
 
-# (required - please provide an IAM Instance Profile ARN)
+# (required, or else certain features may be disabled)
 iam_instance_profile_arn = "$IAM_INSTANCE_PROFILE_ARN"
 
 # (defaults to "us-west-2")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daft_launcher"
-version = "0.3.5"
+version = "0.3.6"
 requires-python = ">=3.9"
 dependencies = [
     "boto3>=1.35.17",


### PR DESCRIPTION
# Overview
Now users can specify a `iam_instance_profile_arn` field in the setup commands which will deploy those permissions to all nodes in the cluster (i.e., the head and all workers).