### PR TITLE
Config updates

### DIFF
--- a/src/template.toml
+++ b/src/template.toml
@@ -11,6 +11,7 @@ version = "<VERSION>"
 provider = "aws"
 region = "us-west-2"
 number-of-workers = 4
+teardown-behavior = "terminate"
 
 # The following configurations specify the type of servers in your cluster.
 # The machine type below is what we usually use at Eventual, and the image id is Ubuntu based.


### PR DESCRIPTION
# Overview

This PR splits the "down" command into 2:
- `stop`: this just stops the cluster (but doesn't kill the nodes)
- `kill`: this stops the cluster *and* kills the nodes

This PR also updates how the `export` command works. Instead of printing to a default `.ray.yaml` file, it instead prints to stdout, and the end-user can then redirect the output however they wish!