### PR TITLE
feat: Add regex searching for `daft list`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +616,7 @@ dependencies = [
  "aws-sdk-sts",
  "clap",
  "comfy-table",
+ "regex",
  "semver",
  "serde",
  "serde_yaml",
@@ -1299,10 +1309,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ clap = { version = "4.5", features = ["derive"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 comfy-table = "7.1.1"
+regex = "1.11.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ build-backend = "maturin"
 bindings = "bin"
 
 [tool.pyright]
-# typeCheckingMode = "off"
 venv = ".venv"
 venvPath = "."
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -551,6 +551,15 @@ pub enum NodeType {
     Worker,
 }
 
+impl NodeType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Head => "head",
+            Self::Worker => "worker",
+        }
+    }
+}
+
 impl FromStr for NodeType {
     type Err = anyhow::Error;
 
@@ -632,11 +641,13 @@ fn format_table(
         .apply_modifier(modifiers::UTF8_ROUND_CORNERS)
         .apply_modifier(modifiers::UTF8_SOLID_INNER_BORDERS)
         .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-        .set_header(["Name", "Instance ID", "Status", "IPv4"].map(|header| {
-            Cell::new(header)
-                .set_alignment(CellAlignment::Center)
-                .add_attribute(Attribute::Bold)
-        }));
+        .set_header(
+            ["Name", "Instance ID", "Node Type", "Status", "IPv4"].map(|header| {
+                Cell::new(header)
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold)
+            }),
+        );
     let regex = regex.as_deref().map(Regex::new).transpose()?;
     for instance in instances.iter().filter(|instance| {
         if head && instance.node_type != NodeType::Head {
@@ -674,7 +685,8 @@ fn format_table(
             .map_or("n/a".into(), ToString::to_string);
         table.add_row(vec![
             Cell::new(instance.regular_name.to_string()).fg(Color::Cyan),
-            Cell::new(&*instance.instance_id),
+            Cell::new(instance.instance_id.as_ref()),
+            Cell::new(instance.node_type.as_str()),
             status,
             Cell::new(ipv4),
         ]);


### PR DESCRIPTION
# Overview

This PR enables the usage of `regex` to filter over the node names.

## Usage

```sh
daft list 'my-cluster-*' --head
```

The above command will filter for all the nodes which are head nodes *and* match the regex `my-cluster-*`. The regex standard used is according to the [`regex`](https://docs.rs/regex/latest/regex/) crate.

This PR also adds the `Node Type` column to the printed out result.