### PR TITLE
fix: Add run commands to outputted ray-config file; remove provider

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -159,7 +159,7 @@ struct ConfigPath {
 struct DaftConfig {
     setup: DaftSetup,
     #[serde(default)]
-    run: DaftRun,
+    run: Vec<StrRef>,
     #[serde(rename = "job", deserialize_with = "parse_jobs")]
     jobs: HashMap<StrRef, DaftJob>,
 }
@@ -200,7 +200,6 @@ struct DaftSetup {
     name: StrRef,
     #[serde(deserialize_with = "parse_version_req")]
     version: VersionReq,
-    provider: DaftProvider,
     region: StrRef,
     #[serde(default = "default_number_of_workers")]
     number_of_workers: usize,
@@ -279,21 +278,6 @@ where
     } else {
         Err(serde::de::Error::custom(format!("You're running daft-launcher version {current_version}, but your configuration file requires version {version_req}")))
     }
-}
-
-#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-enum DaftProvider {
-    Aws,
-}
-
-#[derive(Default, Debug, Deserialize, Clone, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-struct DaftRun {
-    #[serde(default)]
-    pre_setup_commands: Vec<StrRef>,
-    #[serde(default)]
-    post_setup_commands: Vec<StrRef>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -445,6 +429,7 @@ async fn read_and_convert(
                     let deps = format!("uv pip install {deps}").into();
                     commands.push(deps);
                 }
+                commands.extend(daft_config.run.iter().map(Clone::clone));
                 commands
             },
         })

--- a/src/template.toml
+++ b/src/template.toml
@@ -8,7 +8,6 @@
 [setup]
 name = "daft-launcher-example"
 version = "<VERSION>"
-provider = "aws"
 region = "us-west-2"
 number-of-workers = 4
 


### PR DESCRIPTION
# Overview

This PR does two things:
1. It adds the run commands to the outputted ray-config. Previously, they were *not* being added, which was a mistake.
2. It removes the "provider" section. This section is useless right now. Furthermore, as we add another cloud-provider, we'll need to change the configuration schema anyways.