### PR TITLE
feat: Add ability to specify python and ray versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,12 +620,12 @@ dependencies = [
  "open",
  "regex",
  "rstest",
- "semver",
  "serde",
  "serde_yaml",
  "tempdir",
  "tokio",
  "toml",
+ "versions",
 ]
 
 [[package]]
@@ -1128,6 +1128,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1206,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1612,9 +1637,6 @@ name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -2029,6 +2051,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "versions"
+version = "6.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25d498b63d1fdb376b4250f39ab3a5ee8d103957346abacd911e2d8b612c139"
+dependencies = [
+ "itertools",
+ "nom",
+ "serde",
+]
 
 [[package]]
 name = "vsimd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ toml = "0.8.19"
 anyhow = { version = "1.0.89", features = ["backtrace"] }
 tokio = { version = "1.40.0", features = ["full"] }
 clap = { version = "4.5", features = ["derive"] }
-semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 comfy-table = "7.1.1"
 regex = "1.11.1"
 open = "5.3.2"
+versions = { version = "6.3.2", features = ["serde"] }
 
 [dev-dependencies]
 rstest = "0.24.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,20 +6,35 @@ description = "A simple launcher for spinning up and managing Ray clusters for D
 license = "LICENSE"
 
 [dependencies]
-aws-config = "1.5.8"
-aws-sdk-sts = "1.46.0"
-aws-sdk-ec2 = "1.81.0"
-serde_yaml = "0.9.34"
-tempdir = "0.3.7"
-toml = "0.8.19"
-anyhow = { version = "1.0.89", features = ["backtrace"] }
-tokio = { version = "1.40.0", features = ["full"] }
-clap = { version = "4.5", features = ["derive"] }
-serde = { version = "1.0", features = ["derive", "rc"] }
-comfy-table = "7.1.1"
-regex = "1.11.1"
-open = "5.3.2"
-versions = { version = "6.3.2", features = ["serde"] }
+aws-config = "1.5"
+aws-sdk-sts = "1.46"
+aws-sdk-ec2 = "1.81"
+serde_yaml = "0.9"
+tempdir = "0.3"
+toml = "0.8"
+comfy-table = "7.1"
+regex = "1.11"
+open = "5.3"
+
+[dependencies.anyhow]
+version = "1.0"
+features = ["backtrace"]
+
+[dependencies.tokio]
+version = "1.40"
+features = ["full"]
+
+[dependencies.clap]
+version = "4.5"
+features = ["derive"]
+
+[dependencies.serde]
+version = "1.0"
+features = ["derive", "rc"]
+
+[dependencies.versions]
+version = "6.3"
+features = ["serde"]
 
 [dev-dependencies]
-rstest = "0.24.0"
+rstest = "0.24"

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,3 @@
-- [ ] Enable users to specify Ray and python version.
 - [ ] Make `daft up` block until *all* worker nodes are up.
 - [ ] Open up the default browser, create a new tab, and point it towards `localhost:8265` after running `daft connect`.
 - [ ] Add ability to upload a custom daft wheel when initializing a cluster (rather than installing a released daft version).

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
 - [ ] Make `daft up` block until *all* worker nodes are up.
-- [ ] Open up the default browser, create a new tab, and point it towards `localhost:8265` after running `daft connect`.
 - [ ] Add ability to upload a custom daft wheel when initializing a cluster (rather than installing a released daft version).

--- a/src/main.rs
+++ b/src/main.rs
@@ -392,7 +392,10 @@ fn generate_setup_commands(
         "uv venv".into(),
         "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
         "source ~/.bashrc".into(),
-        format!(r#"uv pip install boto3 pip py-spy deltalake getdaft "ray[default]=={ray_version}""#).into(),
+        format!(
+            r#"uv pip install boto3 pip py-spy deltalake getdaft "ray[default]=={ray_version}""#
+        )
+        .into(),
     ];
 
     if !dependencies.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,6 @@ struct DaftSetup {
     python_version: Option<StrRef>,
     #[serde(default, deserialize_with = "parse_optional_soft_version_req")]
     ray_version: Option<StrRef>,
-    daft_wheel: Option<StrRef>,
     region: StrRef,
     #[serde(default = "default_number_of_workers")]
     number_of_workers: usize,
@@ -364,7 +363,6 @@ struct RayResources {
 fn generate_setup_commands(
     python_version: Option<StrRef>,
     ray_version: Option<StrRef>,
-    daft_wheel: Option<StrRef>,
 ) -> Vec<StrRef> {
     let mut commands = vec!["curl -LsSf https://astral.sh/uv/install.sh | sh".into()];
 
@@ -388,12 +386,7 @@ fn generate_setup_commands(
         Some(ray_version) => format!(r#""ray[default]=={ray_version}""#),
         None => "ray[default]".to_string(),
     };
-    commands.push(format!("uv pip install boto3 pip py-spy deltalake {ray_install}").into());
-
-    match daft_wheel {
-        Some(daft_wheel) => commands.push(format!("uv pip install {daft_wheel}").into()),
-        None => commands.push("uv pip install getdaft".into()),
-    }
+    commands.push(format!("uv pip install boto3 pip py-spy deltalake getdaft {ray_install}").into());
 
     commands
 }
@@ -465,7 +458,6 @@ fn convert(
             let mut commands = generate_setup_commands(
                 daft_config.setup.python_version.clone(),
                 daft_config.setup.ray_version.clone(),
-                daft_config.setup.daft_wheel.clone(),
             );
             if !daft_config.setup.dependencies.is_empty() {
                 let deps = daft_config

--- a/src/template.toml
+++ b/src/template.toml
@@ -7,9 +7,9 @@
 
 [setup]
 name = "daft-launcher-example"
-requires = "<REQUIRES>"
-requires-python = "<REQUIRES-PYTHON>"
-requires-ray = "<REQUIRES-RAY>"
+requires = "<requires>"
+python-version = "<python-version>"
+ray-version = "<ray-version>"
 region = "us-west-2"
 number-of-workers = 4
 

--- a/src/template.toml
+++ b/src/template.toml
@@ -7,7 +7,7 @@
 
 [setup]
 name = "daft-launcher-example"
-version = "<VERSION>"
+requires = "<REQUIRES>"
 region = "us-west-2"
 number-of-workers = 4
 

--- a/src/template.toml
+++ b/src/template.toml
@@ -3,7 +3,7 @@
 #
 # For more information on the availale commands and configuration options, visit [here](https://eventual-inc.github.io/daft-launcher).
 #
-# Happy daft-ing!
+# Happy daft-ing 🚀!
 
 [setup]
 name = "daft-launcher-example"

--- a/src/template.toml
+++ b/src/template.toml
@@ -8,6 +8,8 @@
 [setup]
 name = "daft-launcher-example"
 requires = "<REQUIRES>"
+requires-python = "<REQUIRES-PYTHON>"
+requires-ray = "<REQUIRES-RAY>"
 region = "us-west-2"
 number-of-workers = 4
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -83,7 +83,7 @@ fn test_conversion(
 }
 
 #[rstest::rstest]
-#[case(None, None, vec![
+#[case(None, None, vec![], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
@@ -91,7 +91,7 @@ fn test_conversion(
     "source ~/.bashrc".into(),
     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
 ])]
-#[case(Some("3.9".into()), None, vec![
+#[case(Some("3.9".into()), None, vec![], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install 3.9".into(),
     "uv python pin 3.9".into(),
@@ -100,7 +100,7 @@ fn test_conversion(
     "source ~/.bashrc".into(),
     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
 ])]
-#[case(None, Some("2.34".into()), vec![
+#[case(None, Some("2.34".into()), vec![], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
@@ -108,20 +108,22 @@ fn test_conversion(
     "source ~/.bashrc".into(),
     r#"uv pip install boto3 pip py-spy deltalake getdaft "ray[default]==2.34""#.into(),
 ])]
-#[case(None, None, vec![
+#[case(None, None, vec!["requests==0.0.0".into()], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
     "source ~/.bashrc".into(),
     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
+    r#"uv pip install "requests==0.0.0""#.into(),
 ])]
 fn test_generate_setup_commands(
     #[case] python_version: Option<StrRef>,
     #[case] ray_version: Option<StrRef>,
+    #[case] dependencies: Vec<StrRef>,
     #[case] expected: Vec<StrRef>,
 ) {
-    let actual = generate_setup_commands(python_version, ray_version);
+    let actual = generate_setup_commands(python_version, ray_version, dependencies.as_slice());
     assert_eq!(actual, expected);
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -83,24 +83,24 @@ fn test_conversion(
 }
 
 #[rstest::rstest]
-#[case(None, None, vec![], vec![
-    "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
-    "uv python install".into(),
-    "uv venv".into(),
-    "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
-    "source ~/.bashrc".into(),
-    "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
-])]
-#[case(Some("=3.9".parse().unwrap()), None, vec![], vec![
-    "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
-    "uv python install 3.9".into(),
-    "uv python pin 3.9".into(),
-    "uv venv".into(),
-    "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
-    "source ~/.bashrc".into(),
-    "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
-])]
-#[case(None, Some("=2.34".parse().unwrap()), vec![], vec![
+// #[case(None, None, vec![], vec![
+//     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
+//     "uv python install".into(),
+//     "uv venv".into(),
+//     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
+//     "source ~/.bashrc".into(),
+//     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
+// ])]
+// #[case(Some("=3.9".parse().unwrap()), None, vec![], vec![
+//     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
+//     "uv python install 3.9".into(),
+//     "uv python pin 3.9".into(),
+//     "uv venv".into(),
+//     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
+//     "source ~/.bashrc".into(),
+//     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
+// ])]
+#[case("=3.9".parse().unwrap(), "=2.34".parse().unwrap(), vec![], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
@@ -108,7 +108,7 @@ fn test_conversion(
     "source ~/.bashrc".into(),
     r#"uv pip install boto3 pip py-spy deltalake getdaft "ray[default]==2.34""#.into(),
 ])]
-#[case(None, None, vec!["requests==0.0.0".into()], vec![
+#[case("=3.9".parse().unwrap(), "=2.34".parse().unwrap(), vec!["requests==0.0.0".into()], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
@@ -118,8 +118,8 @@ fn test_conversion(
     r#"uv pip install "requests==0.0.0""#.into(),
 ])]
 fn test_generate_setup_commands(
-    #[case] python_version: Option<Requirement>,
-    #[case] ray_version: Option<Requirement>,
+    #[case] python_version: Requirement,
+    #[case] ray_version: Requirement,
     #[case] dependencies: Vec<StrRef>,
     #[case] expected: Vec<StrRef>,
 ) {
@@ -136,8 +136,8 @@ pub fn simple_config() -> (DaftConfig, Option<TeardownBehaviour>, RayConfig) {
         setup: DaftSetup {
             name: test_name.clone(),
             requires: "=1.2.3".parse().unwrap(),
-            requires_python: Some("=3.12".parse().unwrap()),
-            requires_ray: Some("=2.34".parse().unwrap()),
+            requires_python: "=3.12".parse().unwrap(),
+            requires_ray: "=2.34".parse().unwrap(),
             region: test_name.clone(),
             number_of_workers,
             ssh_user: test_name.clone(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -91,7 +91,7 @@ fn test_conversion(
     "source ~/.bashrc".into(),
     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
 ])]
-#[case(Some("3.9".into()), None, vec![], vec![
+#[case(Some("=3.9".parse().unwrap()), None, vec![], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install 3.9".into(),
     "uv python pin 3.9".into(),
@@ -100,7 +100,7 @@ fn test_conversion(
     "source ~/.bashrc".into(),
     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
 ])]
-#[case(None, Some("2.34".into()), vec![], vec![
+#[case(None, Some("=2.34".parse().unwrap()), vec![], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
@@ -118,8 +118,8 @@ fn test_conversion(
     r#"uv pip install "requests==0.0.0""#.into(),
 ])]
 fn test_generate_setup_commands(
-    #[case] python_version: Option<StrRef>,
-    #[case] ray_version: Option<StrRef>,
+    #[case] python_version: Option<Requirement>,
+    #[case] ray_version: Option<Requirement>,
     #[case] dependencies: Vec<StrRef>,
     #[case] expected: Vec<StrRef>,
 ) {
@@ -135,9 +135,9 @@ pub fn simple_config() -> (DaftConfig, Option<TeardownBehaviour>, RayConfig) {
     let daft_config = DaftConfig {
         setup: DaftSetup {
             name: test_name.clone(),
-            version: "1.2.3".parse().unwrap(),
-            python_version: Some("3.12".into()),
-            ray_version: Some("2.34".into()),
+            requires: "=1.2.3".parse().unwrap(),
+            requires_python: Some("=3.12".parse().unwrap()),
+            requires_ray: Some("=2.34".parse().unwrap()),
             region: test_name.clone(),
             number_of_workers,
             ssh_user: test_name.clone(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -83,50 +83,45 @@ fn test_conversion(
 }
 
 #[rstest::rstest]
-#[case(None, None, None, vec![
+#[case(None, None, vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
     "source ~/.bashrc".into(),
-    "uv pip install boto3 pip py-spy deltalake ray[default]".into(),
-    "uv pip install getdaft".into(),
+    "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
 ])]
-#[case(Some("3.9".into()), None, None, vec![
+#[case(Some("3.9".into()), None, vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install 3.9".into(),
     "uv python pin 3.9".into(),
     "uv venv".into(),
     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
     "source ~/.bashrc".into(),
-    "uv pip install boto3 pip py-spy deltalake ray[default]".into(),
-    "uv pip install getdaft".into(),
+    "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
 ])]
-#[case(None, Some("2.34".into()), None, vec![
+#[case(None, Some("2.34".into()), vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
     "source ~/.bashrc".into(),
-    r#"uv pip install boto3 pip py-spy deltalake "ray[default]==2.34""#.into(),
-    "uv pip install getdaft".into(),
+    r#"uv pip install boto3 pip py-spy deltalake getdaft "ray[default]==2.34""#.into(),
 ])]
-#[case(None, None, Some("https://example.com/path/to/wheel.whl".into()), vec![
+#[case(None, None, vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
     "uv python install".into(),
     "uv venv".into(),
     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
     "source ~/.bashrc".into(),
-    "uv pip install boto3 pip py-spy deltalake ray[default]".into(),
-    "uv pip install https://example.com/path/to/wheel.whl".into(),
+    "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
 ])]
 fn test_generate_setup_commands(
     #[case] python_version: Option<StrRef>,
     #[case] ray_version: Option<StrRef>,
-    #[case] daft_wheel: Option<StrRef>,
     #[case] expected: Vec<StrRef>,
 ) {
-    let actual = generate_setup_commands(python_version, ray_version, daft_wheel);
+    let actual = generate_setup_commands(python_version, ray_version);
     assert_eq!(actual, expected);
 }
 
@@ -141,7 +136,6 @@ pub fn simple_config() -> (DaftConfig, Option<TeardownBehaviour>, RayConfig) {
             version: "1.2.3".parse().unwrap(),
             python_version: Some("3.12".into()),
             ray_version: Some("2.34".into()),
-            daft_wheel: None,
             region: test_name.clone(),
             number_of_workers,
             ssh_user: test_name.clone(),
@@ -202,8 +196,7 @@ pub fn simple_config() -> (DaftConfig, Option<TeardownBehaviour>, RayConfig) {
             "uv venv".into(),
             "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
             "source ~/.bashrc".into(),
-            r#"uv pip install boto3 pip py-spy deltalake "ray[default]==2.34""#.into(),
-            "uv pip install getdaft".into(),
+            r#"uv pip install boto3 pip py-spy deltalake getdaft "ray[default]==2.34""#.into(),
         ],
     };
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -83,43 +83,28 @@ fn test_conversion(
 }
 
 #[rstest::rstest]
-// #[case(None, None, vec![], vec![
-//     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
-//     "uv python install".into(),
-//     "uv venv".into(),
-//     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
-//     "source ~/.bashrc".into(),
-//     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
-// ])]
-// #[case(Some("=3.9".parse().unwrap()), None, vec![], vec![
-//     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
-//     "uv python install 3.9".into(),
-//     "uv python pin 3.9".into(),
-//     "uv venv".into(),
-//     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
-//     "source ~/.bashrc".into(),
-//     "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
-// ])]
-#[case("=3.9".parse().unwrap(), "=2.34".parse().unwrap(), vec![], vec![
+#[case("3.9".parse().unwrap(), "2.34".parse().unwrap(), vec![], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
-    "uv python install".into(),
+    "uv python install 3.9".into(),
+    "uv python pin 3.9".into(),
     "uv venv".into(),
     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
     "source ~/.bashrc".into(),
     r#"uv pip install boto3 pip py-spy deltalake getdaft "ray[default]==2.34""#.into(),
 ])]
-#[case("=3.9".parse().unwrap(), "=2.34".parse().unwrap(), vec!["requests==0.0.0".into()], vec![
+#[case("3.9".parse().unwrap(), "2.34".parse().unwrap(), vec!["requests==0.0.0".into()], vec![
     "curl -LsSf https://astral.sh/uv/install.sh | sh".into(),
-    "uv python install".into(),
+    "uv python install 3.9".into(),
+    "uv python pin 3.9".into(),
     "uv venv".into(),
     "echo 'source $HOME/.venv/bin/activate' >> ~/.bashrc".into(),
     "source ~/.bashrc".into(),
-    "uv pip install boto3 pip py-spy deltalake getdaft ray[default]".into(),
+    r#"uv pip install boto3 pip py-spy deltalake getdaft "ray[default]==2.34""#.into(),
     r#"uv pip install "requests==0.0.0""#.into(),
 ])]
 fn test_generate_setup_commands(
-    #[case] python_version: Requirement,
-    #[case] ray_version: Requirement,
+    #[case] python_version: Versioning,
+    #[case] ray_version: Versioning,
     #[case] dependencies: Vec<StrRef>,
     #[case] expected: Vec<StrRef>,
 ) {
@@ -136,8 +121,8 @@ pub fn simple_config() -> (DaftConfig, Option<TeardownBehaviour>, RayConfig) {
         setup: DaftSetup {
             name: test_name.clone(),
             requires: "=1.2.3".parse().unwrap(),
-            requires_python: "=3.12".parse().unwrap(),
-            requires_ray: "=2.34".parse().unwrap(),
+            python_version: "3.12".parse().unwrap(),
+            ray_version: "2.34".parse().unwrap(),
             region: test_name.clone(),
             number_of_workers,
             ssh_user: test_name.clone(),


### PR DESCRIPTION
# Overview

This PR enables the ability to specify both the `ray` and `python` versions that you want installed on the remote Ray cluster.