### PR TITLE
ci: Add build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,47 @@
+name: build-and-test
+
+on:
+  pull_request:
+
+jobs:
+  run-command:
+    runs-on: buildjet-8vcpu-ubuntu-2004
+    steps:
+    - name: Log workflow inputs
+      run: echo "${{ toJson(github.event.inputs) }}"
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Install rust
+      shell: bash
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        CARGO_BIN="$HOME/.cargo/bin"
+        echo 'export PATH="$CARGO_BIN:$PATH"' >> $HOME/.bashrc
+        echo "$CARGO_BIN" >> $GITHUB_PATH
+    - name: Install uv
+      shell: bash
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        UV_BIN="$HOME/.local/bin"
+        echo 'export PATH="$UV_BIN:$PATH"' >> $HOME/.bashrc
+        echo "$UV_BIN" >> $GITHUB_PATH
+    - name: Install (and pin) python version
+      shell: bash
+      run: |
+        uv python install 3.12
+        uv python pin 3.12
+    - name: Setup uv environment
+      run: |
+        uv v
+        source .venv/bin/activate
+        uv pip install ray[default] maturin
+    - name: Build project
+      run: |
+        source .venv/bin/activate
+        maturin develop --uv
+    - name: Run tests
+      run: |
+        source .venv/bin/activate
+        cargo test

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   run-command:
-    runs-on: ubuntu
+    runs-on: ubuntu-latest
     steps:
     - name: Log workflow inputs
       run: echo "${{ toJson(github.event.inputs) }}"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   run-command:
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu
     steps:
     - name: Log workflow inputs
       run: echo "${{ toJson(github.event.inputs) }}"

--- a/.github/workflows/run-rust-tests.yaml
+++ b/.github/workflows/run-rust-tests.yaml
@@ -1,10 +1,10 @@
-name: build-and-test
+name: run-rust-tests
 
 on:
   pull_request:
 
 jobs:
-  run-command:
+  run-rust-tests:
     runs-on: ubuntu-latest
     steps:
     - name: Log workflow inputs
@@ -37,11 +37,13 @@ jobs:
         uv v
         source .venv/bin/activate
         uv pip install ray[default] maturin
-    - name: Build project
-      run: |
-        source .venv/bin/activate
-        maturin develop --uv
+    - name: Restore cache
+      uses: actions/cache@v4
+      with:
+        path: target/release
+        key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-deps-
     - name: Run tests
       run: |
         source .venv/bin/activate
-        cargo test
+        cargo test --release


### PR DESCRIPTION
# Overview

We currently don't have any CI/CD pipelining to run tests prior to merges. This PR introduces a new workflow that builds and tests the code on buildjet machines.